### PR TITLE
Expand MCP functionality with bucket information and object listing tools

### DIFF
--- a/src/minio_mcp/server.py
+++ b/src/minio_mcp/server.py
@@ -32,6 +32,50 @@ async def list_buckets() -> dict:
     return result.response
 
 
+@mcp.tool()
+async def get_bucket_info(bucket_name: str) -> dict:
+    """Get information about a specific bucket.
+
+    Args:
+        bucket_name: The name of the bucket to get information about
+    """
+
+    bucket_tools = BucketTools()
+    if not bucket_name:
+        return "Error: 'bucket_name' parameter is required."
+    if not isinstance(bucket_name, str):
+        return "Error: 'bucket_name' must be a string."
+
+    result = await bucket_tools.get_bucket_info(bucket_name)
+    if result.status_code != 200:
+        return f"Error getting bucket info: {result.error}"
+    return result.response
+
+
+@mcp.tool()
+async def list_objects(bucket_name: str, prefix: str = "", limit: int = 25) -> dict:
+    """List objects in a specific bucket.
+
+    Args:
+        bucket_name: The name of the bucket to list objects from
+        prefix: (Optional) Filter objects by prefix
+        limit: (Optional) Limit the number of objects returned limit=-1 for no limit
+    """
+
+    bucket_tools = BucketTools()
+    if not bucket_name:
+        return "Error: 'bucket_name' parameter is required."
+    if not isinstance(bucket_name, str):
+        return "Error: 'bucket_name' must be a string."
+    if not isinstance(prefix, str):
+        return "Error: 'prefix' must be a string."
+
+    result = await bucket_tools.list_objects(bucket_name, prefix, limit)
+    if result.status_code != 200:
+        return f"Error listing objects: {result.error}"
+    return result.response
+
+
 # Run the server
 if __name__ == "__main__":
     transport = "stdio"  # Use standard input/output for communication

--- a/tests/infrastructure/test_minio_client.py
+++ b/tests/infrastructure/test_minio_client.py
@@ -2,7 +2,8 @@ import os
 from unittest.mock import Mock, patch
 
 import pytest
-from infraestructure.minio_client import FailedConnectionError, MinioClient
+
+from minio_mcp.infrastructure.minio_client import FailedConnectionError, MinioClient
 
 
 class TestMinioClient:
@@ -15,7 +16,7 @@ class TestMinioClient:
             "MINIO_SECURE": "false",
         },
     )
-    @patch("infraestructure.minio_client.Minio")
+    @patch("minio_mcp.infrastructure.minio_client.Minio")
     def test_succesfull_connection(self, mock_minio_class):
         mock_client = Mock()
         mock_client.list_buckets.return_value = iter([])
@@ -30,7 +31,7 @@ class TestMinioClient:
             secure=False,
         )
 
-    @patch("infraestructure.minio_client.Minio")
+    @patch("minio_mcp.infrastructure.minio_client.Minio")
     def test_connection_failure(self, mock_minio_class):
         mock_minio_class.side_effect = Exception("Failed to create a client")
 

--- a/tests/tools/test_bucket_tools.py
+++ b/tests/tools/test_bucket_tools.py
@@ -9,3 +9,30 @@ class TestBucketTools:
         assert result.status_code == 200, f"Error listing buckets: {result.error}"
         assert isinstance(result.response, dict), "Response is not a dictionary"
         assert "buckets" in result.response, "'buckets' key not in response"
+
+    async def test_get_bucket_info(self):
+        bucket_tools = BucketTools()
+        # Replace 'example-bucket' with an actual bucket name for real testing
+        bucket_name = "example-bucket"
+        result = await bucket_tools.get_bucket_info(bucket_name)
+
+        if result.status_code != 200:
+            assert result.status_code == 404, f"Unexpected error: {result.error}"
+        else:
+            assert isinstance(result.response, dict), "Response is not a dictionary"
+            assert "name" in result.response, "'name' key not in response"
+            assert result.response["name"] == bucket_name, "Bucket name does not match"
+
+    async def test_list_objects(self):
+        bucket_tools = BucketTools()
+        # Replace 'example-bucket' with an actual bucket name for real testing
+        bucket_name = "example-bucket"
+        result = await bucket_tools.list_objects(bucket_name, prefix="", limit=10)
+
+        if result.status_code != 200:
+            assert result.status_code == 404, f"Unexpected error: {result.error}"
+        else:
+            assert isinstance(result.response, dict), "Response is not a dictionary"
+            assert "objects" in result.response, "'objects' key not in response"
+            assert isinstance(result.response["objects"], list), "'objects' is not a list"
+            assert len(result.response["objects"]) <= 10, "More objects returned than limit"


### PR DESCRIPTION
## Summary
- Add get_bucket_info tool to retrieve comprehensive bucket metadata including policies, encryption, object count, and total size
- Add list_objects tool with prefix filtering and configurable object limit (default 25, unlimited with -1)
- Enhance test coverage for new bucket management functionality
- Fix import path issues in test files

## New MCP Tools
- **get_bucket_info**: Returns detailed bucket information including creation date, tags, policy, encryption status, object count, and total size
- **list_objects**: Lists objects in a bucket with optional prefix filtering and configurable limits to prevent overwhelming responses

## Test plan
- [x] All existing tests continue to pass
- [x] New test cases for get_bucket_info and list_objects functionality
- [x] Fixed import path issues in infrastructure tests
- [x] Comprehensive parameter validation in MCP tool handlers