### PR TITLE
Add complete bucket management: create and delete tools with force deletion

### DIFF
--- a/src/minio_mcp/server.py
+++ b/src/minio_mcp/server.py
@@ -76,6 +76,47 @@ async def list_objects(bucket_name: str, prefix: str = "", limit: int = 25) -> d
     return result.response
 
 
+@mcp.tool()
+async def create_bucket(bucket_name: str) -> str:
+    """Create a new bucket in the MinIO server.
+
+    Args:
+        bucket_name: The name of the bucket to create
+    """
+
+    bucket_tools = BucketTools()
+    if not bucket_name:
+        return "Error: 'bucket_name' parameter is required."
+    if not isinstance(bucket_name, str):
+        return "Error: 'bucket_name' must be a string."
+
+    result = await bucket_tools.create_bucket(bucket_name)
+    if result.status_code != 200:
+        return f"Error creating bucket: {result.error}"
+    return f"Bucket '{bucket_name}' created successfully."
+
+
+@mcp.tool()
+async def delete_bucket(bucket_name: str, force: bool = False) -> str:
+    """Delete a bucket from the MinIO server.
+
+    Args:
+        bucket_name: The name of the bucket to delete
+        force: If True, delete all objects in the bucket before deleting the bucket,
+    """
+
+    bucket_tools = BucketTools()
+    if not bucket_name:
+        return "Error: 'bucket_name' parameter is required."
+    if not isinstance(bucket_name, str):
+        return "Error: 'bucket_name' must be a string."
+
+    result = await bucket_tools.delete_bucket(bucket_name, force)
+    if result.status_code != 200:
+        return f"Error deleting bucket: {result.error}"
+    return f"Bucket '{bucket_name}' deleted successfully."
+
+
 # Run the server
 if __name__ == "__main__":
     transport = "stdio"  # Use standard input/output for communication

--- a/tests/tools/test_bucket_tools.py
+++ b/tests/tools/test_bucket_tools.py
@@ -1,3 +1,6 @@
+from unittest import mock
+from unittest.mock import Mock, patch
+
 from minio_mcp.tools.bucket_tools import BucketTools
 
 
@@ -36,3 +39,145 @@ class TestBucketTools:
             assert "objects" in result.response, "'objects' key not in response"
             assert isinstance(result.response["objects"], list), "'objects' is not a list"
             assert len(result.response["objects"]) <= 10, "More objects returned than limit"
+
+    @patch("minio_mcp.tools.bucket_tools.MinioClient")
+    async def test_create_bucket_success(self, mock_minio_client_class):
+        # Mock the MinioClient and its methods
+        mock_client = Mock()
+        mock_minio_client_instance = Mock()
+        mock_minio_client_instance.client = mock_client
+        mock_minio_client_class.return_value = mock_minio_client_instance
+
+        # Mock bucket does not exist and creation succeeds
+        mock_client.bucket_exists.return_value = False
+        mock_client.make_bucket.return_value = None
+
+        bucket_tools = BucketTools()
+        bucket_name = "test-bucket"
+        result = await bucket_tools.create_bucket(bucket_name)
+
+        # Assertions
+        assert result.status_code == 200
+        assert isinstance(result.response, dict)
+        assert result.response["message"] == f"Bucket '{bucket_name}' created successfully."
+        mock_client.bucket_exists.assert_called_once_with(bucket_name)
+        mock_client.make_bucket.assert_called_once_with(bucket_name)
+
+    @patch("minio_mcp.tools.bucket_tools.MinioClient")
+    async def test_create_bucket_already_exists(self, mock_minio_client_class):
+        # Mock the MinioClient and its methods
+        mock_client = Mock()
+        mock_minio_client_instance = Mock()
+        mock_minio_client_instance.client = mock_client
+        mock_minio_client_class.return_value = mock_minio_client_instance
+
+        # Mock bucket already exists
+        mock_client.bucket_exists.return_value = True
+
+        bucket_tools = BucketTools()
+        bucket_name = "existing-bucket"
+        result = await bucket_tools.create_bucket(bucket_name)
+
+        # Assertions
+        assert result.status_code == 409
+        assert result.error == f"Bucket '{bucket_name}' already exists."
+        assert result.response == {}
+        mock_client.bucket_exists.assert_called_once_with(bucket_name)
+
+    @patch("minio_mcp.tools.bucket_tools.MinioClient")
+    async def test_delete_empty_bucket_success(self, mock_minio_client_class):
+        # Setup mocks
+        mock_client = Mock()
+        mock_minio_client_instance = Mock()
+        mock_minio_client_instance.client = mock_client
+        mock_minio_client_class.return_value = mock_minio_client_instance
+
+        # Mock bucket exists and is empty
+        mock_client.bucket_exists.return_value = True
+        mock_client.list_objects.return_value = iter([])  # Empty bucket
+        mock_client.remove_bucket.return_value = None
+
+        bucket_tools = BucketTools()
+        bucket_name = "empty-bucket"
+        result = await bucket_tools.delete_bucket(bucket_name, force=False)
+
+        # Assertions
+        assert result.status_code == 200
+        assert isinstance(result.response, dict)
+        assert result.response["message"] == f"Bucket '{bucket_name}' deleted successfully."
+        mock_client.bucket_exists.assert_called_once_with(bucket_name)
+        mock_client.remove_bucket.assert_called_once_with(bucket_name)
+
+    @patch("minio_mcp.tools.bucket_tools.MinioClient")
+    async def test_delete_bucket_not_exists(self, mock_minio_client_class):
+        # Setup mocks
+        mock_client = Mock()
+        mock_minio_client_instance = Mock()
+        mock_minio_client_instance.client = mock_client
+        mock_minio_client_class.return_value = mock_minio_client_instance
+
+        # Mock bucket does not exist
+        mock_client.bucket_exists.return_value = False
+
+        bucket_tools = BucketTools()
+        bucket_name = "nonexistent-bucket"
+        result = await bucket_tools.delete_bucket(bucket_name, force=False)
+
+        # Assertions
+        assert result.status_code == 404
+        assert result.error == f"Bucket '{bucket_name}' does not exist."
+        assert result.response == {}
+        mock_client.bucket_exists.assert_called_once_with(bucket_name)
+
+    @patch("minio_mcp.tools.bucket_tools.MinioClient")
+    async def test_delete_non_empty_bucket_without_force(self, mock_minio_client_class):
+        # Setup mocks
+        mock_client = Mock()
+        mock_minio_client_instance = Mock()
+        mock_minio_client_instance.client = mock_client
+        mock_minio_client_class.return_value = mock_minio_client_instance
+
+        # Mock bucket exists and has objects
+        mock_client.bucket_exists.return_value = True
+        mock_object = Mock()
+        mock_object.object_name = "file.txt"
+        mock_client.list_objects.return_value = iter([mock_object])  # Non-empty bucket
+
+        bucket_tools = BucketTools()
+        bucket_name = "non-empty-bucket"
+        result = await bucket_tools.delete_bucket(bucket_name, force=False)
+
+        # Assertions
+        assert result.status_code == 400
+        assert "is not empty" in result.error
+        assert result.response == {}
+        mock_client.bucket_exists.assert_called_once_with(bucket_name)
+
+    @patch("minio_mcp.tools.bucket_tools.MinioClient")
+    async def test_delete_non_empty_bucket_with_force(self, mock_minio_client_class):
+        # Setup mocks
+        mock_client = Mock()
+        mock_minio_client_instance = Mock()
+        mock_minio_client_instance.client = mock_client
+        mock_minio_client_class.return_value = mock_minio_client_instance
+
+        # Mock bucket exists and has objects
+        mock_client.bucket_exists.return_value = True
+        mock_object = Mock()
+        mock_object.object_name = "file.txt"
+        # list_objects is called twice, so we need to return a fresh iterator each time
+        mock_client.list_objects.side_effect = lambda *args, **kwargs: iter([mock_object])
+        mock_client.remove_object.return_value = None
+        mock_client.remove_bucket.return_value = None
+
+        bucket_tools = BucketTools()
+        bucket_name = "non-empty-bucket"
+        result = await bucket_tools.delete_bucket(bucket_name, force=True)
+
+        # Assertions
+        assert result.status_code == 200
+        assert isinstance(result.response, dict)
+        assert result.response["message"] == f"Bucket '{bucket_name}' deleted successfully."
+        mock_client.bucket_exists.assert_called_once_with(bucket_name)
+        mock_client.remove_object.assert_called_once_with(bucket_name, "file.txt")
+        mock_client.remove_bucket.assert_called_once_with(bucket_name)


### PR DESCRIPTION
## Summary
- Add create_bucket MCP tool with comprehensive validation including bucket name format checking and existence verification
- Add delete_bucket MCP tool with optional force parameter for safe deletion of non-empty buckets
- Implement robust error handling with appropriate HTTP status codes (400, 404, 409, 500)
- Add comprehensive test suite with advanced mocking techniques for all edge cases

## New MCP Tools
- **create_bucket**: Creates new buckets with validation against invalid characters and duplicate names
- **delete_bucket**: Safely deletes buckets with optional force parameter to handle non-empty buckets by removing all objects first

## Key Features
- **Input validation**: Bucket name format checking (no "/" characters)
- **Safety checks**: Existence verification and empty bucket detection
- **Force deletion**: Optional parameter to delete non-empty buckets safely
- **Comprehensive error handling**: Detailed error messages with appropriate status codes
- **Advanced testing**: Mock-based tests covering success/failure scenarios with proper iterator handling

## Test Coverage
- [x] Successful bucket creation and deletion operations
- [x] Bucket already exists (409) and not found (404) error cases
- [x] Empty vs non-empty bucket deletion scenarios
- [x] Force parameter functionality for non-empty bucket deletion
- [x] Advanced mock setup with side_effect for multiple iterator calls
- [x] All tests pass with improved coverage

## Technical Improvements  
- Fixed any() usage in delete_bucket for proper empty bucket detection
- Enhanced test mocking with side_effect for MinIO list_objects iterator behavior
- Consistent parameter validation across all MCP tool handlers