### PR TITLE
Add delete_object MCP tool with comprehensive validation and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server that provides a bridge between MCP-compati
 
 ## Features
 
-- **6 MCP Tools** organized by domain for comprehensive MinIO operations:
+- **7 MCP Tools** organized by domain for comprehensive MinIO operations:
 
 ### Bucket Management
   - `list_buckets`: List all available buckets with creation dates
@@ -12,9 +12,10 @@ A Model Context Protocol (MCP) server that provides a bridge between MCP-compati
   - `create_bucket`: Create new buckets with name validation and existence checks
   - `delete_bucket`: Delete buckets (empty only) or force delete with all contents
 
-### Object Management  
+### Object Management
   - `list_objects`: List objects with filtering (prefix, recursive) and configurable limits (default 25)
   - `get_object_info`: Get detailed object metadata (size, content-type, etag, version info, custom metadata)
+  - `delete_object`: Delete objects from buckets with optional version support for versioned objects
 
 ### Key Features
 - **FastMCP Integration**: Built on FastMCP framework for robust MCP protocol support
@@ -122,6 +123,7 @@ Try commands like:
 - "Show me information about the 'my-bucket' bucket"
 - "List the first 10 objects in 'my-bucket'"
 - "Get information about 'file.txt' in 'my-bucket'"
+- "Delete 'old-file.txt' from 'my-bucket'"
 
 ## Architecture
 

--- a/src/minio_mcp/server.py
+++ b/src/minio_mcp/server.py
@@ -143,6 +143,33 @@ async def get_object_info(bucket_name: str, object_name: str) -> dict:
     return result.response
 
 
+@mcp.tool()
+async def delete_object(bucket_name: str, object_name: str, version_id: str = None) -> str:
+    """Delete a specific object from a bucket.
+    Args:
+        bucket_name: The name of the bucket containing the object
+        object_name: The name of the object to delete
+        version_id: (Optional) The version ID of the object to delete
+    """
+
+    object_tools = ObjectTools()
+    if not bucket_name:
+        return "Error: 'bucket_name' parameter is required."
+    if not isinstance(bucket_name, str):
+        return "Error: 'bucket_name' must be a string."
+    if not object_name:
+        return "Error: 'object_name' parameter is required."
+    if not isinstance(object_name, str):
+        return "Error: 'object_name' must be a string."
+    if version_id is not None and not isinstance(version_id, str):
+        return "Error: 'version_id' must be a string if provided."
+
+    result = await object_tools.delete_object(bucket_name, object_name, version_id)
+    if result.status_code != 200:
+        return f"Error deleting object: {result.error}"
+    return f"Object '{object_name}' deleted successfully from bucket '{bucket_name}'."
+
+
 # Run the server
 if __name__ == "__main__":
     transport = "stdio"  # Use standard input/output for communication

--- a/src/minio_mcp/server.py
+++ b/src/minio_mcp/server.py
@@ -1,6 +1,7 @@
 from mcp.server.fastmcp import FastMCP
 
 from minio_mcp.tools.bucket_tools import BucketTools
+from minio_mcp.tools.object_tools import ObjectTools
 
 # Create an MCP server
 mcp = FastMCP(
@@ -115,6 +116,31 @@ async def delete_bucket(bucket_name: str, force: bool = False) -> str:
     if result.status_code != 200:
         return f"Error deleting bucket: {result.error}"
     return f"Bucket '{bucket_name}' deleted successfully."
+
+
+@mcp.tool()
+async def get_object_info(bucket_name: str, object_name: str) -> dict:
+    """Get information about a specific object in a bucket.
+
+    Args:
+        bucket_name: The name of the bucket containing the object
+        object_name: The name of the object to get information about
+    """
+
+    object_tools = ObjectTools()
+    if not bucket_name:
+        return "Error: 'bucket_name' parameter is required."
+    if not isinstance(bucket_name, str):
+        return "Error: 'bucket_name' must be a string."
+    if not object_name:
+        return "Error: 'object_name' parameter is required."
+    if not isinstance(object_name, str):
+        return "Error: 'object_name' must be a string."
+
+    result = await object_tools.get_object_info(bucket_name, object_name)
+    if result.status_code != 200:
+        return f"Error getting object info: {result.error}"
+    return result.response
 
 
 # Run the server

--- a/src/minio_mcp/tools/object_tools.py
+++ b/src/minio_mcp/tools/object_tools.py
@@ -52,3 +52,47 @@ class ObjectTools:
             status_code=200,
         )
         return text_content
+
+    async def delete_object(
+        self, bucket_name: str, object_name: str, version_id: str | None = None
+    ) -> TextContent:
+        """Delete a specific object from a bucket."""
+        if not self.minio_client.client.bucket_exists(bucket_name):
+            text_content = TextContent(
+                response={},
+                error=f"Bucket '{bucket_name}' does not exist.",
+                status_code=404,
+            )
+            return text_content
+
+        try:
+            if version_id:
+                self.minio_client.client.remove_object(
+                    bucket_name, object_name, version_id=version_id
+                )
+            else:
+                self.minio_client.client.remove_object(bucket_name, object_name)
+        except ValueError:
+            text_content = TextContent(
+                response={},
+                error=f"Object '{object_name}' does not exist in bucket '{bucket_name}'.",
+                status_code=404,
+            )
+            return text_content
+        except Exception as e:
+            text_content = TextContent(
+                response={},
+                error=str(e),
+                status_code=500,
+            )
+            return text_content
+
+        text_content = TextContent(
+            response={
+                "message": (
+                    f"Object '{object_name}' deleted successfully from bucket '{bucket_name}'."
+                )
+            },
+            status_code=200,
+        )
+        return text_content

--- a/src/minio_mcp/tools/object_tools.py
+++ b/src/minio_mcp/tools/object_tools.py
@@ -1,0 +1,54 @@
+from minio_mcp.infrastructure.minio_client import MinioClient
+from minio_mcp.tools.entities import TextContent
+
+
+class ObjectTools:
+    """A class to manage bucket operations in MinIO"""
+
+    def __init__(self):
+        self.minio_client = MinioClient()
+
+    async def get_object_info(self, bucket_name: str, object_name: str) -> TextContent:
+        """Get information about a specific object in a bucket."""
+        if not self.minio_client.client.bucket_exists(bucket_name):
+            text_content = TextContent(
+                response={},
+                error=f"Bucket '{bucket_name}' does not exist.",
+                status_code=404,
+            )
+            return text_content
+
+        try:
+            obj_stat = self.minio_client.client.stat_object(bucket_name, object_name)
+        except ValueError:
+            text_content = TextContent(
+                response={},
+                error=f"Object '{object_name}' does not exist in bucket '{bucket_name}'.",
+                status_code=404,
+            )
+            return text_content
+        except Exception as e:
+            text_content = TextContent(
+                response={},
+                error=str(e),
+                status_code=500,
+            )
+            return text_content
+
+        object_info = {
+            "bucket_name": bucket_name,
+            "object_name": object_name,
+            "size": obj_stat.size,
+            "last_modified": obj_stat.last_modified,
+            "etag": obj_stat.etag,
+            "content_type": obj_stat.content_type,
+            "metadata": obj_stat.metadata,
+            "version_id": obj_stat.version_id,
+            "is_delete_marker": obj_stat.is_delete_marker,
+        }
+
+        text_content = TextContent(
+            response=object_info,
+            status_code=200,
+        )
+        return text_content

--- a/tests/tools/test_object_tools.py
+++ b/tests/tools/test_object_tools.py
@@ -1,0 +1,117 @@
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+from minio_mcp.tools.object_tools import ObjectTools
+
+
+class TestObjectTools:
+    @patch("minio_mcp.tools.object_tools.MinioClient")
+    async def test_get_object_info_success(self, mock_minio_client_class):
+        # Setup mocks
+        mock_client = Mock()
+        mock_minio_client_instance = Mock()
+        mock_minio_client_instance.client = mock_client
+        mock_minio_client_class.return_value = mock_minio_client_instance
+
+        # Mock bucket exists and object stats
+        mock_client.bucket_exists.return_value = True
+        mock_obj_stat = Mock()
+        mock_obj_stat.size = 1024
+        mock_obj_stat.last_modified = datetime(2024, 1, 15, 10, 30, 45)
+        mock_obj_stat.etag = "d41d8cd98f00b204e9800998ecf8427e"
+        mock_obj_stat.content_type = "text/plain"
+        mock_obj_stat.metadata = {"user-key": "user-value"}
+        mock_obj_stat.version_id = "version123"
+        mock_obj_stat.is_delete_marker = False
+        mock_client.stat_object.return_value = mock_obj_stat
+
+        object_tools = ObjectTools()
+        bucket_name = "test-bucket"
+        object_name = "test-file.txt"
+        result = await object_tools.get_object_info(bucket_name, object_name)
+
+        # Assertions
+        assert result.status_code == 200
+        assert isinstance(result.response, dict)
+        assert result.response["bucket_name"] == bucket_name
+        assert result.response["object_name"] == object_name
+        assert result.response["size"] == 1024
+        assert result.response["last_modified"] == datetime(2024, 1, 15, 10, 30, 45)
+        assert result.response["etag"] == "d41d8cd98f00b204e9800998ecf8427e"
+        assert result.response["content_type"] == "text/plain"
+        assert result.response["metadata"] == {"user-key": "user-value"}
+        assert result.response["version_id"] == "version123"
+        assert result.response["is_delete_marker"] is False
+
+        mock_client.bucket_exists.assert_called_once_with(bucket_name)
+        mock_client.stat_object.assert_called_once_with(bucket_name, object_name)
+
+    @patch("minio_mcp.tools.object_tools.MinioClient")
+    async def test_get_object_info_bucket_not_exists(self, mock_minio_client_class):
+        # Setup mocks
+        mock_client = Mock()
+        mock_minio_client_instance = Mock()
+        mock_minio_client_instance.client = mock_client
+        mock_minio_client_class.return_value = mock_minio_client_instance
+
+        # Mock bucket does not exist
+        mock_client.bucket_exists.return_value = False
+
+        object_tools = ObjectTools()
+        bucket_name = "nonexistent-bucket"
+        object_name = "test-file.txt"
+        result = await object_tools.get_object_info(bucket_name, object_name)
+
+        # Assertions
+        assert result.status_code == 404
+        assert result.error == f"Bucket '{bucket_name}' does not exist."
+        assert result.response == {}
+        mock_client.bucket_exists.assert_called_once_with(bucket_name)
+
+    @patch("minio_mcp.tools.object_tools.MinioClient")
+    async def test_get_object_info_object_not_found(self, mock_minio_client_class):
+        # Setup mocks
+        mock_client = Mock()
+        mock_minio_client_instance = Mock()
+        mock_minio_client_instance.client = mock_client
+        mock_minio_client_class.return_value = mock_minio_client_instance
+
+        # Mock bucket exists but object does not
+        mock_client.bucket_exists.return_value = True
+        mock_client.stat_object.side_effect = ValueError("Object not found")
+
+        object_tools = ObjectTools()
+        bucket_name = "test-bucket"
+        object_name = "nonexistent-file.txt"
+        result = await object_tools.get_object_info(bucket_name, object_name)
+
+        # Assertions
+        assert result.status_code == 404
+        assert result.error == f"Object '{object_name}' does not exist in bucket '{bucket_name}'."
+        assert result.response == {}
+        mock_client.bucket_exists.assert_called_once_with(bucket_name)
+        mock_client.stat_object.assert_called_once_with(bucket_name, object_name)
+
+    @patch("minio_mcp.tools.object_tools.MinioClient")
+    async def test_get_object_info_general_error(self, mock_minio_client_class):
+        # Setup mocks
+        mock_client = Mock()
+        mock_minio_client_instance = Mock()
+        mock_minio_client_instance.client = mock_client
+        mock_minio_client_class.return_value = mock_minio_client_instance
+
+        # Mock bucket exists but stat_object fails with general error
+        mock_client.bucket_exists.return_value = True
+        mock_client.stat_object.side_effect = Exception("Connection error")
+
+        object_tools = ObjectTools()
+        bucket_name = "test-bucket"
+        object_name = "test-file.txt"
+        result = await object_tools.get_object_info(bucket_name, object_name)
+
+        # Assertions
+        assert result.status_code == 500
+        assert result.error == "Connection error"
+        assert result.response == {}
+        mock_client.bucket_exists.assert_called_once_with(bucket_name)
+        mock_client.stat_object.assert_called_once_with(bucket_name, object_name)

--- a/tests/tools/test_object_tools.py
+++ b/tests/tools/test_object_tools.py
@@ -115,3 +115,138 @@ class TestObjectTools:
         assert result.response == {}
         mock_client.bucket_exists.assert_called_once_with(bucket_name)
         mock_client.stat_object.assert_called_once_with(bucket_name, object_name)
+
+    @patch("minio_mcp.tools.object_tools.MinioClient")
+    async def test_delete_object_success(self, mock_minio_client_class):
+        # Setup mocks
+        mock_client = Mock()
+        mock_minio_client_instance = Mock()
+        mock_minio_client_instance.client = mock_client
+        mock_minio_client_class.return_value = mock_minio_client_instance
+
+        # Mock bucket exists and object deletion succeeds
+        mock_client.bucket_exists.return_value = True
+        mock_client.remove_object.return_value = None  # Successful deletion
+
+        object_tools = ObjectTools()
+        bucket_name = "test-bucket"
+        object_name = "test-file.txt"
+        result = await object_tools.delete_object(bucket_name, object_name)
+
+        # Assertions
+        assert result.status_code == 200
+        assert isinstance(result.response, dict)
+        assert (
+            result.response["message"]
+            == f"Object '{object_name}' deleted successfully from bucket '{bucket_name}'."
+        )
+        assert result.error is None
+
+        mock_client.bucket_exists.assert_called_once_with(bucket_name)
+        mock_client.remove_object.assert_called_once_with(bucket_name, object_name)
+
+    @patch("minio_mcp.tools.object_tools.MinioClient")
+    async def test_delete_object_with_version_id_success(self, mock_minio_client_class):
+        # Setup mocks
+        mock_client = Mock()
+        mock_minio_client_instance = Mock()
+        mock_minio_client_instance.client = mock_client
+        mock_minio_client_class.return_value = mock_minio_client_instance
+
+        # Mock bucket exists and object deletion with version succeeds
+        mock_client.bucket_exists.return_value = True
+        mock_client.remove_object.return_value = None  # Successful deletion
+
+        object_tools = ObjectTools()
+        bucket_name = "test-bucket"
+        object_name = "test-file.txt"
+        version_id = "version123"
+        result = await object_tools.delete_object(bucket_name, object_name, version_id)
+
+        # Assertions
+        assert result.status_code == 200
+        assert isinstance(result.response, dict)
+        assert (
+            result.response["message"]
+            == f"Object '{object_name}' deleted successfully from bucket '{bucket_name}'."
+        )
+        assert result.error is None
+
+        mock_client.bucket_exists.assert_called_once_with(bucket_name)
+        mock_client.remove_object.assert_called_once_with(
+            bucket_name, object_name, version_id=version_id
+        )
+
+    @patch("minio_mcp.tools.object_tools.MinioClient")
+    async def test_delete_object_bucket_not_exists(self, mock_minio_client_class):
+        # Setup mocks
+        mock_client = Mock()
+        mock_minio_client_instance = Mock()
+        mock_minio_client_instance.client = mock_client
+        mock_minio_client_class.return_value = mock_minio_client_instance
+
+        # Mock bucket does not exist
+        mock_client.bucket_exists.return_value = False
+
+        object_tools = ObjectTools()
+        bucket_name = "nonexistent-bucket"
+        object_name = "test-file.txt"
+        result = await object_tools.delete_object(bucket_name, object_name)
+
+        # Assertions
+        assert result.status_code == 404
+        assert result.error == f"Bucket '{bucket_name}' does not exist."
+        assert result.response == {}
+
+        mock_client.bucket_exists.assert_called_once_with(bucket_name)
+        mock_client.remove_object.assert_not_called()
+
+    @patch("minio_mcp.tools.object_tools.MinioClient")
+    async def test_delete_object_object_not_found(self, mock_minio_client_class):
+        # Setup mocks
+        mock_client = Mock()
+        mock_minio_client_instance = Mock()
+        mock_minio_client_instance.client = mock_client
+        mock_minio_client_class.return_value = mock_minio_client_instance
+
+        # Mock bucket exists but object does not
+        mock_client.bucket_exists.return_value = True
+        mock_client.remove_object.side_effect = ValueError("Object not found")
+
+        object_tools = ObjectTools()
+        bucket_name = "test-bucket"
+        object_name = "nonexistent-file.txt"
+        result = await object_tools.delete_object(bucket_name, object_name)
+
+        # Assertions
+        assert result.status_code == 404
+        assert result.error == f"Object '{object_name}' does not exist in bucket '{bucket_name}'."
+        assert result.response == {}
+
+        mock_client.bucket_exists.assert_called_once_with(bucket_name)
+        mock_client.remove_object.assert_called_once_with(bucket_name, object_name)
+
+    @patch("minio_mcp.tools.object_tools.MinioClient")
+    async def test_delete_object_general_error(self, mock_minio_client_class):
+        # Setup mocks
+        mock_client = Mock()
+        mock_minio_client_instance = Mock()
+        mock_minio_client_instance.client = mock_client
+        mock_minio_client_class.return_value = mock_minio_client_instance
+
+        # Mock bucket exists but remove_object fails with general error
+        mock_client.bucket_exists.return_value = True
+        mock_client.remove_object.side_effect = Exception("Connection error")
+
+        object_tools = ObjectTools()
+        bucket_name = "test-bucket"
+        object_name = "test-file.txt"
+        result = await object_tools.delete_object(bucket_name, object_name)
+
+        # Assertions
+        assert result.status_code == 500
+        assert result.error == "Connection error"
+        assert result.response == {}
+
+        mock_client.bucket_exists.assert_called_once_with(bucket_name)
+        mock_client.remove_object.assert_called_once_with(bucket_name, object_name)


### PR DESCRIPTION
## Summary
- Add new `delete_object` MCP tool for removing objects from MinIO buckets
- Comprehensive validation and error handling for all edge cases
- Support for optional version_id parameter for versioned object deletion

## Test plan
- [x] Unit tests for successful deletion scenarios
- [x] Unit tests for error cases (bucket not found, object not found, general errors)
- [x] Version ID parameter testing
- [x] All tests passing (20/20)